### PR TITLE
resume_crud

### DIFF
--- a/app/config/base.py
+++ b/app/config/base.py
@@ -14,9 +14,8 @@ class BaseConfig(BaseSettings):
     
     image_max_size : int = 5 * 1024 * 1024
     
-    temp_image : str = "temp_image"
+
     image : str = "image"
-    temp_portfolio : str = "temp_portfolio"
     portfolio : str = "portfolio"
     
     

--- a/app/database.py
+++ b/app/database.py
@@ -60,10 +60,7 @@ async def get_db():
     async with AsyncSessionLocal() as session:
         try:
             yield session
-            await session.commit()
-        except Exception:
-            await session.rollback()
-            raise
+
         finally:
             await session.close()
 

--- a/app/login_logic.py
+++ b/app/login_logic.py
@@ -26,68 +26,37 @@ async def get_user_by_id(db: AsyncSession, user_id: str):
             (UsertypeCode.division == "user_type")
             & (UsertypeCode.detail_id == User.user_type),
         )
-        .where(User.unique_id == user_id))
-    
+        .where(User.unique_id == user_id)
+    )
+
     user = await db.execute(stmt)
 
     user = user.first()
-    
+
     return user
 
 
 async def get_user_by_email(db: AsyncSession, email: str):
-    GenderCode = aliased(Code)
-    UsertypeCode = aliased(Code)
 
-    stmt = (
-        select(
-            User,
-            GenderCode.code_detail.label("gender_detail"),
-            UsertypeCode.code_detail.label("user_type_detail"),
-        )
-        .outerjoin(
-            GenderCode,
-            (GenderCode.division == "gender") & (GenderCode.detail_id == User.gender),
-        )
-        .outerjoin(
-            UsertypeCode,
-            (UsertypeCode.division == "user_type")
-            & (UsertypeCode.detail_id == User.user_type),
-        )
-        .where(User.email == email))
-    
+    stmt = select(User).where(User.email == email)
+
     user = await db.execute(stmt)
 
-    user = user.first()
-    
+    user = user.scalar_one_or_none()
+
     return user
 
 
 async def get_user_by_provider(db: AsyncSession, provieder: str, provider_id: str):
-    GenderCode = aliased(Code)
-    UsertypeCode = aliased(Code)
 
-    stmt = (
-        select(
-            User,
-            GenderCode.code_detail.label("gender_detail"),
-            UsertypeCode.code_detail.label("user_type_detail"),
-        )
-        .outerjoin(
-            GenderCode,
-            (GenderCode.division == "gender") & (GenderCode.detail_id == User.gender),
-        )
-        .outerjoin(
-            UsertypeCode,
-            (UsertypeCode.division == "user_type")
-            & (UsertypeCode.detail_id == User.user_type),
-        )
-        .where(User.provider == provieder, User.provider_id == provider_id))
-    
+    stmt = select(User).where(
+        User.provider == provieder, User.provider_id == provider_id
+    )
+
     user = await db.execute(stmt)
 
-    user = user.first()
-    
+    user = user.scalar_one_or_none()
+
     return user
 
 
@@ -129,10 +98,10 @@ async def create_user(
     return new_user
 
 
-def update_login(db: AsyncSession, user_id: str):
-    user = get_user_by_id(db, user_id)
+async def update_login(db: AsyncSession, user_id: str):
+    user = await get_user_by_id(db, user_id)
 
     if user:
         user.last_accessed = datetime.utcnow()
-        db.commit
+        await db.commit()
     return None

--- a/app/resume_util.py
+++ b/app/resume_util.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, joinedload, contains_eager
 from app.models import Code, Resume, File
@@ -52,11 +52,11 @@ async def get_resume_response(db: AsyncSession, resume_id: int):
             contains_eager(Resume.technology_stacks),
             contains_eager(Resume.qualifications),
         )
-        .where(Resume.resume_id == resume_id)
+        .where(and_(Resume.resume_id == resume_id, Resume.is_active == True))
     )
 
     resume = await db.execute(stmt)
 
-    resume = resume.first()
+    resume = resume.unique().first()
 
     return resume

--- a/app/routers/resumes.py
+++ b/app/routers/resumes.py
@@ -1,0 +1,301 @@
+from datetime import datetime
+import json
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from sqlalchemy import and_, delete, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.database import get_db
+from app.models import (
+    Activity,
+    Education,
+    Experience,
+    Project,
+    Qualification,
+    Resume,
+    TechnologyStack,
+    User,
+)
+from app.models import File as FileModel
+from app.resume_util import get_resume_response
+from app.schemas import ResumeCreate, ResumeListResponse, ResumeResponse, ResumeUpdate
+from app.security import get_current_user
+from app.storage_util import (
+    delete_from_storage,
+    generate_presigned_url,
+    generate_unique_filename,
+    upload_to_image,
+    validate_image_file,
+)
+
+
+router = APIRouter(prefix="/resumes", tags=["resumes"])
+
+
+@router.post("", response_model=ResumeResponse)
+async def create_resumes(
+    data: str = Form(...),
+    photo: UploadFile = File(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """일반 이력서 생성"""
+
+    try:
+        resume_data = ResumeCreate(**json.loads(data))
+
+        new_resume = Resume(
+            user_id=current_user.user_id,
+            resume_type=resume_data.resume_type,
+            title=resume_data.title,
+            name=resume_data.name,
+            email=resume_data.email,
+            gender=resume_data.gender,
+            address=resume_data.address,
+            phone=resume_data.phone,
+            military_service=resume_data.military_service,
+            birth_date=resume_data.birth_date,
+            self_introduction=resume_data.self_introduction,
+        )
+        db.add(new_resume)
+        await db.flush()
+        await db.refresh(new_resume)
+
+        for technology_stack in resume_data.technology_stacks:
+            new_tech = TechnologyStack(
+                resume_id=new_resume.resume_id, title=technology_stack.title
+            )
+            db.add(new_tech)
+
+        for experience in resume_data.experiences:
+            new_experience = Experience(
+                resume_id=new_resume.resume_id, **experience.model_dump()
+            )
+            db.add(new_experience)
+
+        for education in resume_data.educations:
+            new_education = Education(
+                resume_id=new_resume.resume_id, **education.model_dump()
+            )
+            db.add(new_education)
+
+        for project in resume_data.projects:
+            new_project = Project(
+                resume_id=new_resume.resume_id, **project.model_dump()
+            )
+            db.add(new_project)
+
+        for activity in resume_data.activities:
+            new_activity = Activity(
+                resume_id=new_resume.resume_id, **activity.model_dump()
+            )
+            db.add(new_activity)
+
+        for qualification in resume_data.qualifications:
+            new_qualification = Qualification(
+                resume_id=new_resume.resume_id, **qualification.model_dump()
+            )
+            db.add(new_qualification)
+
+        if photo:
+            validated: dict = await validate_image_file(photo)
+
+            upload_image = await upload_to_image(file=validated)
+
+            new_image_file = FileModel(
+                fileable_id=new_resume.resume_id,
+                user_id=current_user.user_id,
+                filetype=validated.get("real_format"),
+                fileable_table="resumes",
+                org_file_name=validated.get("filename"),
+                mod_file_name=upload_image.get("unique_filename"),
+                file_key=upload_image.get("temp_key"),
+                purpose="resume_image",
+            )
+            db.add(new_image_file)
+        await db.commit()
+        
+        resume_info = await get_resume_response(db=db, resume_id=new_resume.resume_id)
+        
+        image_url = await generate_presigned_url(resume_info.image_key) if resume_info.image_key else None
+        
+        resume_response = ResumeResponse.model_validate(resume_info).model_dump()
+        
+        resume_response['image_url'] = image_url
+        
+        return resume_response
+    
+    
+    except Exception as e:
+
+        await db.rollback()
+        print(f"error: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="이력서 생성에 실패했습니다.",
+        )
+
+
+@router.put("/{resume_id}", response_model=ResumeResponse)
+async def update_resume(
+    resume_id: int,
+    data: str = Form(...),
+    photo: UploadFile = File(None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """이력서 수정 엔드포인트"""
+
+    try:
+        resume = await db.get(Resume, resume_id)
+
+        if resume is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="존재하지 않는 이력서 입니다.",
+            )
+
+        if resume.user_id != current_user.user_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="잘못된 접근입니다."
+            )
+
+        resume_data = ResumeUpdate(**json.loads(data))
+
+        for c in [
+            "title",
+            "name",
+            "email",
+            "gender",
+            "address",
+            "phone",
+            "military_service",
+            "birth_date",
+            "self_introduction",
+        ]:
+            setattr(resume, c, getattr(resume_data, c))
+        resume.updated_at = datetime.utcnow()
+
+        tech_stmt = delete(TechnologyStack).where(
+            TechnologyStack.resume_id == resume_id
+        )
+        experience_stmt = delete(Experience).where(Experience.resume_id == resume_id)
+        education_stmt = delete(Education).where(Education.resume_id == resume_id)
+        project_stmt = delete(Project).where(Project.resume_id == resume_id)
+        activity_stmt = delete(Activity).where(Activity.resume_id == resume_id)
+        qualification_stmt = delete(Qualification).where(
+            Qualification.resume_id == resume_id
+        )
+
+        for i in [
+            tech_stmt,
+            experience_stmt,
+            education_stmt,
+            project_stmt,
+            activity_stmt,
+            qualification_stmt,
+        ]:
+            await db.execute(i)
+
+        for technology_stack in resume_data.technology_stacks:
+            new_tech = TechnologyStack(
+                resume_id=resume_id, title=technology_stack.title
+            )
+            db.add(new_tech)
+
+        for experience in resume_data.experiences:
+            new_experience = Experience(resume_id=resume_id, **experience.model_dump())
+            db.add(new_experience)
+
+        for education in resume_data.educations:
+            new_education = Education(resume_id=resume_id, **education.model_dump())
+            db.add(new_education)
+
+        for project in resume_data.projects:
+            new_project = Project(resume_id=resume_id, **project.model_dump())
+            db.add(new_project)
+
+        for activity in resume_data.activities:
+            new_activity = Activity(resume_id=resume_id, **activity.model_dump())
+            db.add(new_activity)
+
+        for qualification in resume_data.qualifications:
+            new_qualification = Qualification(
+                resume_id=resume_id, **qualification.model_dump()
+            )
+            db.add(new_qualification)
+            
+
+        
+        resume_info = await get_resume_response(resume_id=resume_id, db=db)
+        image_key =resume_info.image_key
+        
+        if photo:
+            await delete_from_storage(image_key)
+
+            validated: dict = await validate_image_file(photo)
+
+            upload_image = await upload_to_image(file=validated)
+
+            await db.execute(
+                update(FileModel)
+                .where(
+                    and_(
+                        FileModel.fileable_id == resume_id,
+                        FileModel.purpose == "resume_image",
+                    )
+                )
+                .values(
+                    filetype=validated.get("real_format"),
+                    org_file_name=validated.get("filename"),
+                    mod_file_name=upload_image.get("unique_filename"),
+                    file_key=upload_image.get("temp_key")
+                )
+            )
+            
+            image_url = await generate_presigned_url(upload_image.get("temp_key"))
+        else :
+            image_url = await generate_presigned_url(image_key)
+            
+            
+        await db.commit()
+        
+
+        resume_response = ResumeResponse.model_validate(resume_info).model_dump()
+        
+        resume_response['image_url'] = image_url
+        
+        return resume_response
+        
+
+    except Exception as e:
+        print(f"error : {str(e)}")
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="이력서 수정에 실패했습니다.")
+
+
+
+@router.patch('/{resume_id}')
+async def deactivate_resume(resume_id: int, db: AsyncSession = Depends(get_db), current_user : User = Depends(get_current_user)):
+    '''이력서를 비활성화(삭제) 하는 엔드포인트'''
+    
+    try:
+        resume = await db.get(Resume, resume_id)
+
+        if resume is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="존재하지 않는 이력서 입니다.",
+            )
+
+        if resume.user_id != current_user.user_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail="잘못된 접근입니다."
+            )
+        
+        resume.is_active = False
+        
+        await db.commit()
+    
+    except Exception as e:
+        print(f"error : {str(e)}")
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="이력서 삭제에 실패 했습니다.")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -221,7 +221,8 @@ class TechnologyStackResponse(BaseModel):
 
 # ===== 이력서 스키마 =====
 class ResumeCreate(BaseModel):
-    title: Optional[str] = Field(default="내 이력서", max_length=30)
+    resume_type : str = Field(max_length=10)
+    title: str = Field(min_length=2, max_length=30)
     name: TrimmedStr = Field(max_length=50)
     email: EmailStr = Field(max_length=50)
     gender: str

--- a/app/storage_util.py
+++ b/app/storage_util.py
@@ -52,11 +52,12 @@ def generate_unique_filename(real_format: str) -> str:
     return f"{uuid4()}.{real_format.lower()}"
 
 
-async def upload_to_temp_image(file: dict, real_format: str) -> dict:
-    """스토리지의 임시 이미지 폴더에 저장하는 함수"""
-
+async def upload_to_image(file: dict) -> dict:
+    """스토리지의 이미지 폴더에 저장하는 함수"""
+    
+    real_format = file.get('real_format')
     unique_filename = generate_unique_filename(real_format)
-    temp_key = f"{settings.temp_image}/{unique_filename}"
+    temp_key = f"{settings.image}/{unique_filename}"
 
     s3_client.upload_fileobj(
         io.BytesIO(file["contents"]),
@@ -68,21 +69,6 @@ async def upload_to_temp_image(file: dict, real_format: str) -> dict:
     return {"unique_filename": unique_filename, "temp_key": temp_key}
 
 
-async def move_to_image_dir(temp_key: str, folder: str = "image") -> dict:
-    """스토리지의 임시 폴더에서 실제 저장 폴더로 이동하는 함수"""
-
-    filename = Path(temp_key).name
-    permanent_key = f"{folder}/{filename}"
-
-    s3_client.copy_object(
-        Bucket=settings.aws_bucket_name,
-        CopySource={"Bucket": settings.aws_bucket_name, "Key": temp_key},
-        Key=permanent_key,
-    )
-
-    s3_client.delete_object(Bucket=settings.aws_bucket_name, Key=temp_key)
-
-    return {"filename": filename, "permanent_key": permanent_key}
 
 
 async def delete_from_storage(key: str):
@@ -103,36 +89,3 @@ async def generate_presigned_url(
     )
 
     return url
-
-
-async def delete_temp_folder(folder_prefix: str):
-    """스토리지의 임시 폴더 내용을 비우는 함수"""
-
-    continuation_token = None
-
-    while True:
-
-        params = {
-            "Bucket": settings.aws_bucket_name,
-            "Prefix": f"{folder_prefix}/",
-            "MaxKeys": 1000,
-        }
-    
-        if continuation_token:
-            params['ContinuationToken'] = continuation_token
-        
-        response = s3_client.list_objects_v2(**params)
-        
-        if "Contents" in response:
-            objects = [{"Key": obj["Key"]} for obj in response['Contents']]
-            
-            s3_client.delete_objects(
-                Bucket = settings.aws_bucket_name,
-                Delete = {"Objects": objects}
-            )
-        
-        
-        if not response.get("IsTruncated"):
-            break
-        
-        continuation_token = response.get("NextContinuationToken")


### PR DESCRIPTION
### 이력서 관리 API 엔드포인트

이력서 생성, 수정, 비활성화 기능

### 엔드포인트

**POST /resumes**
- 이력서 생성
- 프로필 이미지 업로드 지원
- 기술 스택, 경력, 학력, 프로젝트, 활동, 자격증 정보 포함

**PUT /resumes/{resume_id}**
- 이력서 수정
- 기존 데이터 삭제 후 재생성 방식
- 프로필 이미지 교체 지원

**PATCH /resumes/{resume_id}**
- 이력서 비활성화 (soft delete)
- is_active 필드를 False로 변경